### PR TITLE
Fix return command

### DIFF
--- a/src/Commands/PreCommitHook.php
+++ b/src/Commands/PreCommitHook.php
@@ -27,7 +27,7 @@ class PreCommitHook extends Command
     /**
      * Execute the console command.
      *
-     * @return bool
+     * @return int
      * @throws \JakubOnderka\PhpConsoleColor\InvalidStyleException
      */
     public function handle()
@@ -61,7 +61,7 @@ class PreCommitHook extends Command
 
         $output->writeLine('Your code is perfect, no syntax error found!', TextOutputColored::TYPE_OK);
 
-        return true;
+        return 0;
     }
 
     /**


### PR DESCRIPTION

> Symfony Console, which is the underlying component that powers Artisan, expects all commands to return an integer. Therefore, you should ensure that any of your commands which return a value are returning integer

public function handle()
{
    // Before...
    return true;

    // After...
    return 0;
}
Check more at: https://github.com/laravel/framework/pull/33278